### PR TITLE
Remove packages and versions file characters that prevent meteor to start

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -7,7 +7,11 @@
 meteor-platform
 autopublish
 insecure
-<<<<<<< HEAD
 momentjs:moment
-=======
->>>>>>> bf6eac34f845d85cf37fa9443b4b529ddd5bad2a
+
+# twbs:bootstrap
+# iron:router
+# sacha:spin
+# ian:accounts-ui-bootstrap-3
+# accounts-password
+# alanning:roles

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -27,10 +27,7 @@ meteor-platform@1.2.2
 minifiers@1.1.5
 minimongo@1.0.8
 mobile-status-bar@1.0.3
-<<<<<<< HEAD
 momentjs:moment@2.10.3
-=======
->>>>>>> bf6eac34f845d85cf37fa9443b4b529ddd5bad2a
 mongo@1.1.0
 observe-sequence@1.0.6
 ordered-dict@1.0.3


### PR DESCRIPTION
Some extra lines in these to files prevent meteor to compile/start. There are some strings as below:
<<<<<<<     HEAD
# momentjs:moment

> > > > > > > bf6eac34f845d85cf37fa9443b4b529ddd5bad2a

$ meteor list
=> Errors while initializing project:         

While reading project metadata:
/Users/konstantinos/Development/meteor/code/chatAppML/.meteor/versions: Package names can only contain
lowercase ASCII alphanumerics, dash, dot, or colon, not "<".
/Users/konstantinos/Development/meteor/code/chatAppML/.meteor/versions: Package names can only contain
lowercase ASCII alphanumerics, dash, dot, or colon, not "=".
/Users/konstantinos/Development/meteor/code/chatAppML/.meteor/versions: Package names can only contain
lowercase ASCII alphanumerics, dash, dot, or colon, not ">".
